### PR TITLE
Add views so that JSON exporter appears as a tab on the Export page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Dradis Framework X.XX (XXXX, 2021) ##
+
+*   Add views so that JSON exporter appears as a tab on the Export page
+
 ## Dradis Framework 3.22 (April, 2021) ##
 
 *   No changes

--- a/app/views/dradis/plugins/json/export/_index-content.html.erb
+++ b/app/views/dradis/plugins/json/export/_index-content.html.erb
@@ -1,0 +1,10 @@
+<%= content_tag :div, id: 'plugin-json', class: 'tab-pane fade' do %>
+  <%= form_tag project_export_manager_path(current_project), target: '_blank' do %>
+    <%= hidden_field_tag :plugin, :json %>
+    <%= hidden_field_tag :route, :root %>
+
+    <h4 class="header-underline">Ready when you are!</h4>
+
+    <button id="export-button" class="btn btn-lg btn-primary mt-4">Export</button>
+  <% end %>
+<% end%>

--- a/app/views/dradis/plugins/json/export/_index-tabs.html.erb
+++ b/app/views/dradis/plugins/json/export/_index-tabs.html.erb
@@ -1,0 +1,3 @@
+<li class='nav-item'>
+  <a href='#json' class='nav-link' data-toggle='tab' data-target='#plugin-json'>Generate JSON reports</a>
+</li>

--- a/lib/dradis/plugins/json/gem_version.rb
+++ b/lib/dradis/plugins/json/gem_version.rb
@@ -9,7 +9,7 @@ module Dradis
       module VERSION
         MAJOR = 3
         MINOR = 22
-        TINY  = 0
+        TINY  = 1
         PRE   = nil
 
         STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")


### PR DESCRIPTION
### Summary

Currently, if you install the JSON exporter, it does not show up on the Export page as an available tab. This PR resolves this by adding in the missing views. 

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.
