### PR TITLE
Update Dradis links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+v4.12.0 (XXXX 2024)
+  - Update Dradis links in README
+
 v4.11.0 (January 2024)
   - No changes
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Export Dradis findings into JavaScript Object Notation (JSON) format.
 
 ## Installation
 
-The plugin requires [Dradis Community Edition](http://dradisframework.org) 3.1 or [Dradis Professional Edition](http://securityroots.com/dradispro/) 2.0 or higher.
+The plugin requires [Dradis CE](http://dradis.com/ce/) > 3.0 or [Dradis Pro](http://dradis.com/) 2.0 or higher.
 
 Add the JSON plugin to your `Gemfile.plugins`:
 


### PR DESCRIPTION
### Summary

Update README so that Dradis CE and Dradis links are now using https://dradis.com/ce/ and https://dradis.com/ respectively.

### Copyright assignment

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
- [ ] Added specs
